### PR TITLE
Add `mode` on URL Launcher's `.launch()` for OS itself to handle URLs.

### DIFF
--- a/packages/khalti/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/khalti/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,8 @@
 import FlutterMacOS
 import Foundation
 
-import device_info_plus_macos
-import package_info_plus_macos
+import device_info_plus
+import package_info_plus
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {

--- a/packages/khalti_flutter/CHANGELOG.md
+++ b/packages/khalti_flutter/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [2.2.1] - Feb 14, 2023
+- Fix redirection issue after bank payments.
+
 # [2.2.0] - Feb 9, 2023
 - Upgraded dependencies.
 

--- a/packages/khalti_flutter/example/pubspec.yaml
+++ b/packages/khalti_flutter/example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   flutter_svg: ^2.0.0+1
   intl: '>=0.17.0 <0.19.0'
-  khalti_flutter: ^2.1.0
+  khalti_flutter: ^2.2.1
   provider: ^6.0.5
 
 dev_dependencies:

--- a/packages/khalti_flutter/lib/src/util/url_launcher_util.dart
+++ b/packages/khalti_flutter/lib/src/util/url_launcher_util.dart
@@ -35,6 +35,7 @@ class UrlLauncherUtil {
       await launcher.launchUrl(
         Uri.parse(url),
         webOnlyWindowName: openInNewTab ? null : '_self',
+        mode: launcher.LaunchMode.externalApplication,
       );
       return true;
     } on PlatformException catch (e) {

--- a/packages/khalti_flutter/pubspec.yaml
+++ b/packages/khalti_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: khalti_flutter
 description: An official Flutter plugin for Khalti Payment Gateway, with all the necessary interface that make it easy to integrate with your app.
-version: 2.2.0
+version: 2.2.1
 homepage: https://khalti.com/payment-gateway/
 documentation: https://docs.khalti.com/
 issue_tracker: https://github.com/khalti/khalti-flutter-sdk/issues


### PR DESCRIPTION
In previous version, URL launcher would open banking sites in in-app-webview which was creating issue on redirection after payment is done.